### PR TITLE
Showcase view selection preview

### DIFF
--- a/src/components/Showcase/CodeDialog/CodeDialog.css
+++ b/src/components/Showcase/CodeDialog/CodeDialog.css
@@ -2,6 +2,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 0.5rem;
 }
 
 #dialog {

--- a/src/components/Showcase/Showcase.js
+++ b/src/components/Showcase/Showcase.js
@@ -37,16 +37,19 @@ export default class Showcase extends Component {
 					role='Recruiter'
 					description='A streamlined overview of some features I want to showcase. If you have hands-on coding experience, consider checking out the developer view.'
 					codeBackgroundReq='No hands-on programming experience required.'
+					link='/Showcase'
 				/>
 				<ViewShowcase
 					role='Developer'
 					description='An in depth walkthrough of features and accompanying explanation of code. Recruiters with hands-on coding experience may want to check this out.'
 					codeBackgroundReq='Web development with knowledge of React is preferable.'
+					link='/Showcase'
 				/>
 				<ViewShowcase
 					role='Friends and Family'
 					description='The simplest overview of the demos. My grandma should be able to understand these demos <3'
 					codeBackgroundReq='No coding background required.'
+					link='/Showcase'
 				/>
 				<GraphQLDemo showCode={this.state.showCode} />
 			</Aux>

--- a/src/components/Showcase/Showcase.js
+++ b/src/components/Showcase/Showcase.js
@@ -8,6 +8,7 @@ import ToggleCode from './ToggleCode/ToggleCode';
 // <----- Styling ----->
 import '../../App.css';
 import './Showcase.css';
+import ViewShowcase from './ViewPreview/ViewPreview';
 
 export default class Showcase extends Component {
 	constructor(props) {
@@ -31,6 +32,7 @@ export default class Showcase extends Component {
 			<Aux className='App'>
 				<h1>Showcase</h1>
 				<ToggleCode onClick={this.toggleCode} />
+				<ViewShowcase />
 				<GraphQLDemo showCode={this.state.showCode} />
 			</Aux>
 		);

--- a/src/components/Showcase/Showcase.js
+++ b/src/components/Showcase/Showcase.js
@@ -42,6 +42,11 @@ export default class Showcase extends Component {
 					description='An in depth walkthrough of features and accompanying explanation of code. Recruiters with hands-on coding experience may want to check this out.'
 					codeBackgroundReq='Web development with knowledge of React is preferable.'
 				/>
+				<ViewShowcase
+					role='Friends and Family'
+					description='The simplest overview of the demos. My grandma should be able to understand these demos <3'
+					codeBackgroundReq='No coding background required.'
+				/>
 				<GraphQLDemo showCode={this.state.showCode} />
 			</Aux>
 		);

--- a/src/components/Showcase/Showcase.js
+++ b/src/components/Showcase/Showcase.js
@@ -32,7 +32,6 @@ export default class Showcase extends Component {
 			<Aux className='App'>
 				<h1>Showcase</h1>
 				{/* <ToggleCode onClick={this.toggleCode} /> */}
-				<hr />
 				<ViewPreview
 					role='Recruiter'
 					description='A streamlined overview of some features I want to showcase. If you have hands-on coding experience, consider checking out the developer view.'
@@ -42,12 +41,12 @@ export default class Showcase extends Component {
 				<ViewPreview
 					role='Developer'
 					description='An in depth walkthrough of features and accompanying explanation of code. Recruiters with hands-on coding experience may want to check this out.'
-					codeBackgroundReq='Web development with knowledge of React is preferable.'
+					codeBackgroundReq='Web development. Knowledge of React is preferable.'
 					link='/Showcase'
 				/>
 				<ViewPreview
 					role='Friends and Family'
-					description='The simplest overview of the demos. My grandma should be able to understand these demos <3'
+					description='The simplest overview of the demos. My grandma should be able to understand them <3'
 					codeBackgroundReq='No coding background required.'
 					link='/Showcase'
 				/>

--- a/src/components/Showcase/Showcase.js
+++ b/src/components/Showcase/Showcase.js
@@ -32,6 +32,7 @@ export default class Showcase extends Component {
 			<Aux className='App'>
 				<h1>Showcase</h1>
 				<ToggleCode onClick={this.toggleCode} />
+				<hr />
 				<ViewShowcase
 					role='Recruiter'
 					description='A streamlined overview of some features I want to showcase. If you have hands-on coding experience, consider checking out the developer view.'

--- a/src/components/Showcase/Showcase.js
+++ b/src/components/Showcase/Showcase.js
@@ -34,8 +34,13 @@ export default class Showcase extends Component {
 				<ToggleCode onClick={this.toggleCode} />
 				<ViewShowcase
 					role='Recruiter'
-					description='A streamlined overview of some features I want to showcase.'
+					description='A streamlined overview of some features I want to showcase. If you have hands-on coding experience, consider checking out the developer view.'
 					codeBackgroundReq='No hands-on programming experience required.'
+				/>
+				<ViewShowcase
+					role='Developer'
+					description='An in depth walkthrough of features and accompanying explanation of code. Recruiters with hands-on coding experience may want to check this out.'
+					codeBackgroundReq='Web development with knowledge of React is preferable.'
 				/>
 				<GraphQLDemo showCode={this.state.showCode} />
 			</Aux>

--- a/src/components/Showcase/Showcase.js
+++ b/src/components/Showcase/Showcase.js
@@ -8,7 +8,7 @@ import ToggleCode from './ToggleCode/ToggleCode';
 // <----- Styling ----->
 import '../../App.css';
 import './Showcase.css';
-import ViewShowcase from './ViewPreview/ViewPreview';
+import ViewPreview from './ViewPreview/ViewPreview';
 
 export default class Showcase extends Component {
 	constructor(props) {
@@ -31,27 +31,27 @@ export default class Showcase extends Component {
 		return (
 			<Aux className='App'>
 				<h1>Showcase</h1>
-				<ToggleCode onClick={this.toggleCode} />
+				{/* <ToggleCode onClick={this.toggleCode} /> */}
 				<hr />
-				<ViewShowcase
+				<ViewPreview
 					role='Recruiter'
 					description='A streamlined overview of some features I want to showcase. If you have hands-on coding experience, consider checking out the developer view.'
 					codeBackgroundReq='No hands-on programming experience required.'
 					link='/Showcase'
 				/>
-				<ViewShowcase
+				<ViewPreview
 					role='Developer'
 					description='An in depth walkthrough of features and accompanying explanation of code. Recruiters with hands-on coding experience may want to check this out.'
 					codeBackgroundReq='Web development with knowledge of React is preferable.'
 					link='/Showcase'
 				/>
-				<ViewShowcase
+				<ViewPreview
 					role='Friends and Family'
 					description='The simplest overview of the demos. My grandma should be able to understand these demos <3'
 					codeBackgroundReq='No coding background required.'
 					link='/Showcase'
 				/>
-				<GraphQLDemo showCode={this.state.showCode} />
+				{/* <GraphQLDemo showCode={this.state.showCode} /> */}
 			</Aux>
 		);
 	}

--- a/src/components/Showcase/Showcase.js
+++ b/src/components/Showcase/Showcase.js
@@ -32,7 +32,11 @@ export default class Showcase extends Component {
 			<Aux className='App'>
 				<h1>Showcase</h1>
 				<ToggleCode onClick={this.toggleCode} />
-				<ViewShowcase />
+				<ViewShowcase
+					role='Recruiter'
+					description='A streamlined overview of some features I want to showcase.'
+					codeBackgroundReq='No hands-on programming experience required.'
+				/>
 				<GraphQLDemo showCode={this.state.showCode} />
 			</Aux>
 		);

--- a/src/components/Showcase/Showcase.js
+++ b/src/components/Showcase/Showcase.js
@@ -36,7 +36,7 @@ export default class Showcase extends Component {
 					role='Recruiter'
 					description='A streamlined overview of some features I want to showcase. If you have hands-on coding experience, consider checking out the developer view.'
 					codeBackgroundReq='No hands-on programming experience required.'
-					link='/Showcase'
+					link='/showcase/recruiter'
 				/>
 				<ViewPreview
 					role='Developer'

--- a/src/components/Showcase/ViewPreview/ViewPreview.js
+++ b/src/components/Showcase/ViewPreview/ViewPreview.js
@@ -6,22 +6,37 @@ import './ViewShowcase.css';
 // <----- MUI ----->
 import Button from '@material-ui/core/Button';
 import { Link } from 'react-router-dom';
+import DeveloperModeIcon from '@material-ui/icons/DeveloperMode';
+import WorkOutlineIcon from '@material-ui/icons/WorkOutline';
+import PeopleOutlineIcon from '@material-ui/icons/PeopleOutline';
+import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
 
 export default function ViewShowcase(props) {
 	return (
 		<Aux>
 			<div id='body'>
-				<h1 className='view-title'>{props.role} View</h1>
-
-				<p>{props.description}</p>
-				<p>{props.codeBackgroundReq}</p>
 				<div className='center'>
-					<Link to={props.link}>
-						<Button variant='outlined' color='primary'>
-							View as {props.role}
-						</Button>
-					</Link>
+					<Button
+						variant='outlined'
+						color='primary'
+						size='large'
+						href={props.link}
+					>
+						View as {props.role}
+						{props.role === 'Recruiter' ? (
+							<WorkOutlineIcon />
+						) : props.role === 'Developer' ? (
+							<DeveloperModeIcon />
+						) : props.role === 'Friends and Family' ? (
+							<PeopleOutlineIcon />
+						) : (
+							<HelpOutlineIcon />
+						)}
+					</Button>
 				</div>
+				<p>
+					{props.description} {props.codeBackgroundReq}
+				</p>
 				<hr />
 			</div>
 		</Aux>

--- a/src/components/Showcase/ViewPreview/ViewPreview.js
+++ b/src/components/Showcase/ViewPreview/ViewPreview.js
@@ -21,6 +21,7 @@ export default function ViewShowcase(props) {
 						color='primary'
 						size='medium'
 						href={props.link}
+						disabled={props.role === 'Recruiter' ? false : true}
 					>
 						View as {props.role}
 						{props.role === 'Recruiter' ? (

--- a/src/components/Showcase/ViewPreview/ViewPreview.js
+++ b/src/components/Showcase/ViewPreview/ViewPreview.js
@@ -11,13 +11,15 @@ export default function ViewShowcase(props) {
 		<Aux>
 			<div id='body'>
 				<h1 className='view-title'>{props.role} View</h1>
+
+				<p>{props.description}</p>
+				<p>{props.codeBackgroundReq}</p>
 				<div className='center'>
 					<Button variant='outlined' color='primary'>
 						View as {props.role}
 					</Button>
 				</div>
-				<p>{props.description}</p>
-				<p>{props.codeBackgroundReq}</p>
+				<hr />
 			</div>
 		</Aux>
 	);

--- a/src/components/Showcase/ViewPreview/ViewPreview.js
+++ b/src/components/Showcase/ViewPreview/ViewPreview.js
@@ -10,16 +10,14 @@ export default function ViewShowcase(props) {
 	return (
 		<Aux>
 			<div id='body'>
-				<h1 className='view-title'>ROLE View</h1>
+				<h1 className='view-title'>{props.role} View</h1>
 				<div className='center'>
 					<Button variant='outlined' color='primary'>
-						View as ROLE
+						View as {props.role}
 					</Button>
 				</div>
-				<p>
-					A ROLE BASED QUALIFIER of some features I want to showcase.
-				</p>
-				<p>EXPERIENCE NEEDED SNIPPET</p>
+				<p>{props.description}</p>
+				<p>{props.codeBackgroundReq}</p>
 			</div>
 		</Aux>
 	);

--- a/src/components/Showcase/ViewPreview/ViewPreview.js
+++ b/src/components/Showcase/ViewPreview/ViewPreview.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import Aux from '../../hocs/Aux';
+import './ViewShowcase.css';
+
+// <----- MUI ----->
+import Button from '@material-ui/core/Button';
+
+export default function ViewShowcase(props) {
+	return (
+		<Aux>
+			<div id='body'>
+				<h1 className='view-title'>ROLE View</h1>
+				<div className='center'>
+					<Button variant='outlined' color='primary'>
+						View as ROLE
+					</Button>
+				</div>
+				<p>
+					A ROLE BASED QUALIFIER of some features I want to showcase.
+				</p>
+				<p>EXPERIENCE NEEDED SNIPPET</p>
+			</div>
+		</Aux>
+	);
+}

--- a/src/components/Showcase/ViewPreview/ViewPreview.js
+++ b/src/components/Showcase/ViewPreview/ViewPreview.js
@@ -5,6 +5,7 @@ import './ViewShowcase.css';
 
 // <----- MUI ----->
 import Button from '@material-ui/core/Button';
+import { Link } from 'react-router-dom';
 
 export default function ViewShowcase(props) {
 	return (
@@ -15,9 +16,11 @@ export default function ViewShowcase(props) {
 				<p>{props.description}</p>
 				<p>{props.codeBackgroundReq}</p>
 				<div className='center'>
-					<Button variant='outlined' color='primary'>
-						View as {props.role}
-					</Button>
+					<Link to={props.link}>
+						<Button variant='outlined' color='primary'>
+							View as {props.role}
+						</Button>
+					</Link>
 				</div>
 				<hr />
 			</div>

--- a/src/components/Showcase/ViewPreview/ViewPreview.js
+++ b/src/components/Showcase/ViewPreview/ViewPreview.js
@@ -19,7 +19,7 @@ export default function ViewShowcase(props) {
 					<Button
 						variant='outlined'
 						color='primary'
-						size='large'
+						size='medium'
 						href={props.link}
 					>
 						View as {props.role}
@@ -35,9 +35,13 @@ export default function ViewShowcase(props) {
 					</Button>
 				</div>
 				<p>
-					{props.description} {props.codeBackgroundReq}
+					<b>Audience: </b>
+					{props.description}
 				</p>
-				<hr />
+				<p>
+					<b>Code Background: </b>
+					{props.codeBackgroundReq}
+				</p>
 			</div>
 		</Aux>
 	);

--- a/src/components/Showcase/ViewPreview/ViewShowcase.css
+++ b/src/components/Showcase/ViewPreview/ViewShowcase.css
@@ -1,5 +1,9 @@
 #body {
     margin-bottom: 0.5rem;
+    border: 2px solid #d4d4b6;
+    background-color: #e6e6bc;
+    border-radius: 5%;
+    padding: 2px;
 }
 
 .view-title {

--- a/src/components/Showcase/ViewPreview/ViewShowcase.css
+++ b/src/components/Showcase/ViewPreview/ViewShowcase.css
@@ -1,0 +1,7 @@
+#body {
+    border: 1px solid red;
+}
+
+.view-title {
+    display: block;
+}

--- a/src/components/Showcase/ViewPreview/ViewShowcase.css
+++ b/src/components/Showcase/ViewPreview/ViewShowcase.css
@@ -1,5 +1,5 @@
 #body {
-    border: 1px solid red;
+    margin-bottom: 0.5rem;
 }
 
 .view-title {


### PR DESCRIPTION
`Showcase FC` now only shows previews of roles (recruiter/developer/friends&family) instead of the GraphQL demo. Demos will be embedded in the respective roles page, which will be found by going through the title button of each preview.  

Was a little inconsistent with tagging issues per each commit, but at least I had some tagging.

Project: 'Showcase View Selection'
Closes #4 (Integrate view showcase previews to Showcase) 
Closes #5 (Create friends/family view showcase) 
Closes #6 (Create developer view showcase) 
Closes #7 (Create recruiter view showcase)