### PR TITLE
Tailor css of showcase to desktop

### DIFF
--- a/src/components/Showcase/GraphQLDemo/GraphQLDemo.js
+++ b/src/components/Showcase/GraphQLDemo/GraphQLDemo.js
@@ -9,6 +9,7 @@ import CodeDialog from '../CodeDialog/CodeDialog';
 
 // <----- Styling ----->
 import './GraphQLDemo.scss';
+import '../../UI/_theme.scss';
 
 // <----- GQL/Apollo ----->
 import { gql, useQuery } from '@apollo/client';
@@ -67,7 +68,7 @@ export default function GraphQLDemo(props) {
 		return `Error! ${errorCMS.message || errorDEMO.message}`;
 
 	return (
-		<Aux>
+		<div id='graph-ql-demo' className='center-block'>
 			<h2>{dataDEMO.demoCode.title}</h2>
 			<h3>{dataCMS.graphQLDemo.h2} </h3>
 			<p>{dataCMS.graphQLDemo.p1}</p>
@@ -121,6 +122,6 @@ export default function GraphQLDemo(props) {
 					/>
 				</Aux>
 			)}
-		</Aux>
+		</div>
 	);
 }

--- a/src/components/Showcase/GraphQLDemo/GraphQLDemo.scss
+++ b/src/components/Showcase/GraphQLDemo/GraphQLDemo.scss
@@ -4,13 +4,6 @@
 	flex-wrap: wrap;
 }
 
-.center-img {
-	margin-left: auto;
-	margin-right: auto;
-	max-width: 100%;
-	display: block;
-}
-
 .cms-view {
 	width: 500px;
 	padding-bottom: 1rem;

--- a/src/components/Showcase/GraphQLDemo/GraphQLDemo.scss
+++ b/src/components/Showcase/GraphQLDemo/GraphQLDemo.scss
@@ -8,3 +8,13 @@
 	width: 500px;
 	padding-bottom: 1rem;
 }
+
+#graph-ql-demo {
+	width: 90% !important;
+}
+
+@media only screen and (min-width: 600px) {
+	#graph-ql-demo {
+		width: 60% !important;
+	}
+}

--- a/src/components/Showcase/Showcase.js
+++ b/src/components/Showcase/Showcase.js
@@ -5,6 +5,7 @@ import Aux from '../hocs/Aux';
 
 // <----- Styling ----->
 import './Showcase.scss';
+import '../UI/_theme.scss';
 import ViewPreview from './ViewPreview/ViewPreview';
 
 export default class Showcase extends Component {
@@ -26,7 +27,7 @@ export default class Showcase extends Component {
 
 	render() {
 		return (
-			<Aux>
+			<div id='showcase' className='center-block'>
 				<h1>Showcase</h1>
 				<h3>Developer and Friends/Family Section coming soon</h3>
 				<ViewPreview
@@ -47,7 +48,7 @@ export default class Showcase extends Component {
 					codeBackgroundReq='No coding background required.'
 					link='/Showcase'
 				/>
-			</Aux>
+			</div>
 		);
 	}
 }

--- a/src/components/Showcase/Showcase.js
+++ b/src/components/Showcase/Showcase.js
@@ -47,7 +47,6 @@ export default class Showcase extends Component {
 					codeBackgroundReq='No coding background required.'
 					link='/Showcase'
 				/>
-				{/* <GraphQLDemo showCode={this.state.showCode} /> */}
 			</Aux>
 		);
 	}

--- a/src/components/Showcase/Showcase.scss
+++ b/src/components/Showcase/Showcase.scss
@@ -1,3 +1,9 @@
 #showcase {
 	width: 90% !important;
 }
+
+@media only screen and (min-width: 600px) {
+	#showcase {
+		width: 60% !important;
+	}
+}

--- a/src/components/Showcase/Showcase.scss
+++ b/src/components/Showcase/Showcase.scss
@@ -1,0 +1,3 @@
+#showcase {
+	width: 90% !important;
+}

--- a/src/components/Showcase/Showcase.scss
+++ b/src/components/Showcase/Showcase.scss
@@ -1,5 +1,0 @@
-.code-toggle {
-	margin-left: auto;
-	margin-right: auto;
-	width: 30%;
-}

--- a/src/components/UI/TitledImage/TitledImage.js
+++ b/src/components/UI/TitledImage/TitledImage.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import Aux from '../../hocs/Aux';
 
+import '../_theme.scss';
+
 export default function TitledImage(props) {
 	return (
 		<Aux>
@@ -8,7 +10,7 @@ export default function TitledImage(props) {
 			<img
 				src={props.imgURL}
 				alt={props.alt}
-				className='center-img cms-view'
+				className='center-block cms-view'
 			/>
 		</Aux>
 	);

--- a/src/components/UI/_theme.scss
+++ b/src/components/UI/_theme.scss
@@ -15,3 +15,10 @@ $theme-lighter: lighten($theme-color, 5%);
 .centered-text {
 	text-align: center;
 }
+
+.center-block {
+	margin-left: auto;
+	margin-right: auto;
+	max-width: 100%;
+	display: block;
+}


### PR DESCRIPTION
Mostly maxing out the width of the main part of the showcase page and the GQL demo page.

Will address #26 (Display images side by side on desktop) later 